### PR TITLE
Added LunaConfig option for multiplier of base price that NPCs will offer to buy eligible player ships.

### DIFF
--- a/jars/sources/ExerelinCore/exerelin/campaign/intel/missions/BuyShip.java
+++ b/jars/sources/ExerelinCore/exerelin/campaign/intel/missions/BuyShip.java
@@ -24,6 +24,7 @@ import com.fs.starfarer.api.util.Misc;
 import com.fs.starfarer.api.util.Misc.Token;
 import com.fs.starfarer.api.util.WeightedRandomPicker;
 import exerelin.campaign.intel.missions.BuyShipRule.*;
+import exerelin.utilities.NexConfig;
 import exerelin.utilities.StringHelper;
 import lombok.extern.log4j.Log4j;
 
@@ -47,7 +48,7 @@ public class BuyShip extends HubMissionWithBarEvent {
 		AVAILABLE_RULES.add(SModRule.class);
 	}
 
-	public static float BASE_PRICE_MULT = 1.6f;
+	public static float BASE_PRICE_MULT = NexConfig.buyShipBasePriceMult;
 
 	public enum Variation {
 		MILITARY, COLLECTOR

--- a/jars/sources/ExerelinCore/exerelin/utilities/LunaConfigHelper.java
+++ b/jars/sources/ExerelinCore/exerelin/utilities/LunaConfigHelper.java
@@ -116,6 +116,7 @@ public class LunaConfigHelper implements LunaSettingsListener {
         addSetting("enableStrategicAI", "boolean", NexConfig.enableStrategicAI);
         addSetting("showStrategicAI", "boolean", NexConfig.showStrategicAI);
         addSetting("enableVictory", "boolean", NexConfig.enableVictory);
+        addSetting("buyShipBasePriceMult", "float", NexConfig.buyShipBasePriceMult);
         addSetting("hardModeColonyGrowthMult", "float", NexConfig.hardModeColonyGrowthMult, 0.5f, 1f);
         addSetting("hardModeColonyIncomeMult", "float", NexConfig.hardModeColonyIncomeMult, 0.5f, 1f);
         addSetting("enablePunitiveExpeditions", "boolean", NexConfig.enablePunitiveExpeditions);

--- a/jars/sources/ExerelinCore/exerelin/utilities/NexConfig.java
+++ b/jars/sources/ExerelinCore/exerelin/utilities/NexConfig.java
@@ -177,6 +177,7 @@ public class NexConfig
     public static boolean allyVictories = true;
     public static boolean updateMarketDescOnCapture = true;
     public static boolean enableNexColonyCrises = true;
+    public static float buyShipBasePriceMult = 1.6f;
 
     public static void loadSettings()
     {
@@ -323,6 +324,7 @@ public class NexConfig
             enableStrategicAI = settings.optBoolean("enableStrategicAI", enableStrategicAI);
             showStrategicAI = settings.optBoolean("showStrategicAI", showStrategicAI);
             enableVictory = settings.optBoolean("enableVictory", enableVictory);
+            buyShipBasePriceMult = (float) settings.optDouble("buyShipBasePriceMult", buyShipBasePriceMult);
             
             builtInFactions = JSONArrayToStringArray(settings.getJSONArray("builtInFactions"));
             


### PR DESCRIPTION
I wanted to be able to decrease the amount that NPCs will pay for ships, since the default 1.6x base price multiplier enables some degeneracy in early game esp with mods that have set locations for salvagable ships. Added as LunaConfig option, PRing in case you'd like to incorporate.