### PR TITLE
Expand random colonies options

### DIFF
--- a/data/strings/strings.json
+++ b/data/strings/strings.json
@@ -1968,6 +1968,8 @@
 		"maxMarketsTitle":"Maximum inhabited planets + stations per system",
 		"randomColoniesTitle":"Extra colonies at start",
 		"randomColoniesTooltip":"Follows the same selection rules as midgame colony expeditions.",
+		"randomColoniesMaxSize":"Maximum colony size",
+		"randomColoniesMaxSizeTooltip":"Maximum size of generated colonies. Minimum size is 3.",
 		"randomizeFactionsTooltip":"Every faction has a 50% chance to be enabled (except independents, which will not be toggled from their current setting).",
 		
 		"infoCustomPanel":"Mouse over option titles for more information",

--- a/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/Nex_NGCProcessSectorGenerationSliders.java
+++ b/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/Nex_NGCProcessSectorGenerationSliders.java
@@ -79,7 +79,7 @@ public class Nex_NGCProcessSectorGenerationSliders extends BaseCommandPlugin {
 		}
 		else {
 			opts.addSelector(getString("randomColoniesTitle"), "randomColoniesSelector", 
-					Color.YELLOW, BAR_WIDTH, 48, 0, 1000, ValueDisplayMode.VALUE,
+					Color.YELLOW, BAR_WIDTH, 48, 0, 250, ValueDisplayMode.VALUE,
 					getString("randomColoniesTooltip"));
 			opts.setSelectorValue("randomColoniesSelector", data.randomColonies);
 			// Maximum size of generated colonies

--- a/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/Nex_NGCProcessSectorGenerationSliders.java
+++ b/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/Nex_NGCProcessSectorGenerationSliders.java
@@ -79,9 +79,14 @@ public class Nex_NGCProcessSectorGenerationSliders extends BaseCommandPlugin {
 		}
 		else {
 			opts.addSelector(getString("randomColoniesTitle"), "randomColoniesSelector", 
-					Color.YELLOW, BAR_WIDTH, 48, 0, 50, ValueDisplayMode.VALUE, 
+					Color.YELLOW, BAR_WIDTH, 48, 0, 1000, ValueDisplayMode.VALUE,
 					getString("randomColoniesTooltip"));
 			opts.setSelectorValue("randomColoniesSelector", data.randomColonies);
+			// Maximum size of generated colonies
+			opts.addSelector(getString("randomColoniesMaxSize"), "randomColoniesMaxSizeSelector",
+					Color.YELLOW, BAR_WIDTH, 48, 3, 10, ValueDisplayMode.VALUE,
+					getString("randomColoniesMaxSizeTooltip"));
+			opts.setSelectorValue("randomColoniesMaxSizeSelector", data.randomColoniesMaxSize);
 		}
 		
 		opts.addOption(StringHelper.getString("back", true), "exerelinNGCSectorOptionsBack");
@@ -94,6 +99,7 @@ public class Nex_NGCProcessSectorGenerationSliders extends BaseCommandPlugin {
 		
 		if (data.corvusMode) {
 			data.randomColonies = Math.round(opts.getSelectorValue("randomColoniesSelector"));
+			data.randomColoniesMaxSize = Math.round(opts.getSelectorValue("randomColoniesMaxSizeSelector"));
 		} else {
 			data.numSystems = Math.round(opts.getSelectorValue("systemCountSelector"));
 			data.numPlanets = Math.round(opts.getSelectorValue("planetCountSelector"));

--- a/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/salvage/Nex_DecivEvent.java
+++ b/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/salvage/Nex_DecivEvent.java
@@ -280,7 +280,7 @@ public class Nex_DecivEvent extends BaseCommandPlugin {
 		PlanetAPI planet = market.getPlanetEntity();
 		FactionAPI faction = Global.getSector().getFaction(Factions.INDEPENDENT);
 		
-		ColonyExpeditionIntel.createColonyStatic(market, planet, faction, true, false);
+		ColonyExpeditionIntel.createColonyStatic(market, planet, faction, true, false, 3);
 		
 		PersonAPI person = getPerson(market);
 		

--- a/jars/sources/ExerelinCore/exerelin/campaign/ColonyManager.java
+++ b/jars/sources/ExerelinCore/exerelin/campaign/ColonyManager.java
@@ -978,14 +978,14 @@ public class ColonyManager extends BaseCampaignEventListener implements EveryFra
 		log.info("Attempting to generate instant colony");
 		String factionId = pickFactionToColonize(random, false);
 		if (factionId == null) {
-			log.info("Failed to pick faction for colony");
+			// log.info("Failed to pick faction for colony");
 			return false;
 		}
 		FactionAPI faction = Global.getSector().getFaction(factionId);
 		
 		MarketAPI source = pickColonyExpeditionSource(factionId, random);
 		if (source == null) {
-			log.info("Failed to pick source market for colony");
+			// log.info("Failed to pick source market for colony");
 			return false;
 		}
 		SectorEntityToken anchor;
@@ -994,14 +994,14 @@ public class ColonyManager extends BaseCampaignEventListener implements EveryFra
 		
 		PlanetAPI target = pickColonyExpeditionTarget(factionId, anchor, true);
 		if (target == null) {
-			log.info("Failed to pick target for colony");
+			// log.info("Failed to pick target for colony");
 			return false;
 		}
 
 		// Generate colony with random size
 		int marketSize = 3 + (int)(Math.random() * (maxSize - 3));
 		ColonyExpeditionIntel.createColonyStatic(target.getMarket(), target, faction, false, false, marketSize);
-		log.info("Generated colony of size " + marketSize);
+		// log.info("Generated colony of size " + marketSize);
 
 		return true;
 	}

--- a/jars/sources/ExerelinCore/exerelin/campaign/ColonyManager.java
+++ b/jars/sources/ExerelinCore/exerelin/campaign/ColonyManager.java
@@ -973,19 +973,19 @@ public class ColonyManager extends BaseCampaignEventListener implements EveryFra
 	 * @param random
 	 * @return
 	 */
-	public boolean generateInstantColony(Random random) 
+	public boolean generateInstantColony(Random random, int maxSize) 
 	{
 		log.info("Attempting to generate instant colony");
 		String factionId = pickFactionToColonize(random, false);
 		if (factionId == null) {
-			//log.info("Failed to pick faction for colony");
+			log.info("Failed to pick faction for colony");
 			return false;
 		}
 		FactionAPI faction = Global.getSector().getFaction(factionId);
 		
 		MarketAPI source = pickColonyExpeditionSource(factionId, random);
 		if (source == null) {
-			//log.info("Failed to pick source market for colony");
+			log.info("Failed to pick source market for colony");
 			return false;
 		}
 		SectorEntityToken anchor;
@@ -997,8 +997,12 @@ public class ColonyManager extends BaseCampaignEventListener implements EveryFra
 			log.info("Failed to pick target for colony");
 			return false;
 		}
-		
-		ColonyExpeditionIntel.createColonyStatic(target.getMarket(), target, faction, false, false);
+
+		// Generate colony with random size
+		int marketSize = 3 + (int)(Math.random() * (maxSize - 3));
+		ColonyExpeditionIntel.createColonyStatic(target.getMarket(), target, faction, false, false, marketSize);
+		log.info("Generated colony of size " + marketSize);
+
 		return true;
 	}
 	

--- a/jars/sources/ExerelinCore/exerelin/campaign/ExerelinSetupData.java
+++ b/jars/sources/ExerelinCore/exerelin/campaign/ExerelinSetupData.java
@@ -30,6 +30,7 @@ public class ExerelinSetupData
 	public int maxPlanetsPerSystem = 3;
 	public int maxMarketsPerSystem = 4;	// includes stations
 	public int randomColonies = 0;
+	public int randomColoniesMaxSize = 3;
 	public Map<String, Boolean> factions = new HashMap<>();
 	
 	// Game defaults

--- a/jars/sources/ExerelinCore/exerelin/campaign/intel/colony/ColonyExpeditionIntel.java
+++ b/jars/sources/ExerelinCore/exerelin/campaign/intel/colony/ColonyExpeditionIntel.java
@@ -361,20 +361,20 @@ public class ColonyExpeditionIntel extends OffensiveFleetIntel implements RaidDe
 	public void createColony() {
 		MarketAPI target = getTarget();
 		String oldName = target.getName();
-		createColonyStatic(target, planet, faction, false, playerSpawned);
+		createColonyStatic(target, planet, faction, false, playerSpawned, 3);
 		String newName = target.getName();
 		if (!oldName.equals(newName))
 			this.newName = newName;
 	}
 	
 	public static void createColonyStatic(MarketAPI market, PlanetAPI planet, 
-			FactionAPI faction, boolean fromDeciv, boolean isPlayer) 
+			FactionAPI faction, boolean fromDeciv, boolean isPlayer, int marketSize)
 	{
 		log.info("Colonizing market " + market.getName() + ", " + market.getId());
 		String factionId = faction.getId();
 		
-		market.setSize(3);
-		market.addCondition("population_3");
+		market.setSize(marketSize);
+		market.addCondition("population_" + marketSize);
 		market.setFactionId(factionId);
 		market.setPlanetConditionMarketOnly(false);
 		market.getMemoryWithoutUpdate().set(MEMORY_KEY_COLONY, true);

--- a/jars/sources/ExerelinCore/exerelin/plugins/ExerelinModPlugin.java
+++ b/jars/sources/ExerelinCore/exerelin/plugins/ExerelinModPlugin.java
@@ -772,14 +772,15 @@ public class ExerelinModPlugin extends BaseModPlugin
             }
             
             int count = ExerelinSetupData.getInstance().randomColonies;
-            int tries = 0;
+            int tries = count * 5;
             Random random = new Random(NexUtils.getStartingSeed());
+            int maxSize = ExerelinSetupData.getInstance().randomColoniesMaxSize;
             while (count > 0) {
-                boolean success = ColonyManager.getManager().generateInstantColony(random);
+                boolean success = ColonyManager.getManager().generateInstantColony(random, maxSize);
                 if (success)
                     count--;
-                tries++;
-                if (tries >= 1000)
+                tries--;
+                if (tries == 0)
                     break;
             }
         }


### PR DESCRIPTION
- expand slider to allow up to 250 random colonies
- add new slider for random colony max size
- colony sizes are uniform between a minimum of 3 and maximum of user choice

I found this useful when playing with "Adjusted Sector" to help prevent the sector from being too empty. 

![image](https://github.com/user-attachments/assets/ce7bd6cb-69f4-4a58-a435-5d8b2b4fa51f)
