### PR TITLE
Miscelaneous Starting Menu Tweaks

### DIFF
--- a/data/campaign/rules.csv
+++ b/data/campaign/rules.csv
@@ -2,10 +2,13 @@ id,trigger,conditions,script,text,options,notes
 #RULESET_NAME Nexerelin,,,,,,
 ,,,,,,
 # NGC options,,,,,,
-ExerelinOnNewGameCreationStart,BeginNewGameCreation,!$doesFakeVariableExist score:999,"$isInIntro = true 0
-$introPage = 1.0 0
-FireAll ExerelinNGCIntroPage
+ExerelinOnNewGameCreationStart,BeginNewGameCreation,!$doesFakeVariableExist score:999,"FireBest ExerelinNGCIntroPicker
 NGCGetExerelinDefaults",,,override SS+ NGC
+,,,,,,
+ExerelinNGCSkipIntro,ExerelinNGCIntroPicker,NGCIntroPicker 0,FireAll ExerelinNGCStep1,,,
+ExerelinNGCDoIntro,ExerelinNGCIntroPicker,!NGCIntroPicker 0,"$isInIntro = true 0
+$introPage = 1.0 0
+FireAll ExerelinNGCIntroPage",,,
 ,,,,,,
 ExerelinNGCIntroNextPage,NewGameOptionSelected,$option==exerelinNGCIntroNextPage,"$introPage++
 FireAll ExerelinNGCIntroPage",,,
@@ -13,7 +16,8 @@ ExerelinNGCIntroPrevPage,NewGameOptionSelected,$option==exerelinNGCIntroPrevPage
 FireAll ExerelinNGCIntroPage",,,
 ,,,,,,
 ExerelinNGCIntro1,ExerelinNGCIntroPage,"$introPage == 1.0
-$isInIntro","SetShortcut exerelinNGCIntroNextPage RETURN
+$isInIntro","NGCIntroPicker true
+SetShortcut exerelinNGCIntroNextPage RETURN
 SetShortcut exerelinNGCIntroEnd ESCAPE",">>> GREETINGS, STARFARER <<<
 
 Welcome to the Nexerelin mod for Starsector!

--- a/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/NGCIntroPicker.java
+++ b/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/NGCIntroPicker.java
@@ -1,0 +1,26 @@
+package com.fs.starfarer.api.impl.campaign.rulecmd.newgame;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fs.starfarer.api.Global;
+import com.fs.starfarer.api.campaign.InteractionDialogAPI;
+import com.fs.starfarer.api.campaign.rules.MemoryAPI;
+import com.fs.starfarer.api.impl.campaign.rulecmd.BaseCommandPlugin;
+import com.fs.starfarer.api.util.Misc.Token;
+import exerelin.ExerelinConstants;
+import lunalib.lunaUtil.LunaCommons;
+
+public class NGCIntroPicker extends BaseCommandPlugin {
+    @Override
+    public boolean execute(String ruleId, InteractionDialogAPI dialog, List<Token> params, Map<String, MemoryAPI> memoryMap) {
+        boolean set = params.get(0).getBoolean(memoryMap);
+
+        if (set) {
+            LunaCommons.set(ExerelinConstants.MOD_ID, "nex_ngcViewedIntro", true);
+            return true;
+        }
+
+        return Boolean.TRUE.equals(LunaCommons.getBoolean(ExerelinConstants.MOD_ID, "nex_ngcViewedIntro")) && !Global.getSettings().isDevMode();
+    }
+}

--- a/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/Nex_NGCListFactions.java
+++ b/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/Nex_NGCListFactions.java
@@ -8,7 +8,7 @@ import com.fs.starfarer.api.campaign.rules.MemKeys;
 import com.fs.starfarer.api.campaign.rules.MemoryAPI;
 import com.fs.starfarer.api.impl.campaign.rulecmd.Nex_FactionDirectoryHelper;
 import com.fs.starfarer.api.impl.campaign.rulecmd.Nex_FactionDirectoryHelper.FactionListGrouping;
-import com.fs.starfarer.api.impl.campaign.rulecmd.PaginatedOptions;
+import com.fs.starfarer.api.impl.campaign.rulecmd.PaginatedOptionsPlus;
 import com.fs.starfarer.api.util.Misc;
 import exerelin.campaign.ExerelinSetupData;
 import exerelin.utilities.NexConfig;
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class Nex_NGCListFactions extends PaginatedOptions {
+public class Nex_NGCListFactions extends PaginatedOptionsPlus {
 	
 	public static final String JOIN_FACTION_OPTION_PREFIX = "nex_NGCJoinFaction_";
 	public static final String LIST_FACTIONS_IN_GROUP_OPTION_PREFIX = "nex_NGCListFactionsGroup_";

--- a/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/Nex_NGCPrintFactionDesc.java
+++ b/jars/sources/ExerelinCore/com/fs/starfarer/api/impl/campaign/rulecmd/newgame/Nex_NGCPrintFactionDesc.java
@@ -27,9 +27,11 @@ public class Nex_NGCPrintFactionDesc extends BaseCommandPlugin {
             if (faction.isPlayerFaction()) {
                 str = StringHelper.getString("exerelin_ngc", "factionDesc_player");
             }
-            sub.addPara(str, 0);
-            tt.addImageWithText(0);
-            dialog.getTextPanel().addTooltip();
+            if (!str.isBlank() && !str.equals("No description... yet")) {
+                sub.addPara(str, 0);
+                tt.addImageWithText(0);
+                dialog.getTextPanel().addTooltip();
+            }
         } catch (Exception ex) {
 
         }


### PR DESCRIPTION
- The intro dialog introducing the mod now only plays once per game (always plays in devmode),
- The faction picker paginator no longer splits the options across two pages when not necessary,
- Factions without descriptions no longer show a "No description... yet" banner;

NOTE: this PR does not include the recompiled jar.